### PR TITLE
command to backup docker conf file is not working

### DIFF
--- a/bag8/utils.py
+++ b/bag8/utils.py
@@ -71,7 +71,7 @@ def write_conf(path, content, bak_path=None):
 
     # keep
     if bak_path:
-        call('cp', path, bak_path)
+        call(['cp', path, bak_path])
 
     cmd = [
         'sudo',


### PR DESCRIPTION
this line is wrong: https://github.com/novafloss/bag8/blob/494cd03ad32e2c3f1a3f64708f43863eed7d495e/bag8/utils.py#L74

because you're not using a list/tuple as the first argument, it results in:

```
TypeError: bufsize must be an integer
```


**Note**: I've tried to run the tests, they've failed. I have no clue on how to add a test that validates this command.
