### PR TITLE
Moves to specific dnsdock_image

### DIFF
--- a/bag8/config.py
+++ b/bag8/config.py
@@ -28,6 +28,8 @@ class Config(object):
         self._data_paths = [
             '.'  # current dir before all
         ] + data.get('data_paths', [])
+        self.dnsdock_image = data.get('dnsdock_image',
+                                      'tonistiigi/dnsdock:v1.10.0')
 
     def iter_data_paths(self):
         for p in self._data_paths:

--- a/bag8/tools.py
+++ b/bag8/tools.py
@@ -109,7 +109,7 @@ server=/{1}/{2}
                 '-v', '/var/run/docker.sock:/var/run/docker.sock',
                 '--name', 'dnsdock',
                 '-p', '172.17.42.1:53:53/udp',
-                'tonistiigi/dnsdock',
+                config.dnsdock_image,
                 "-domain={0}".format(config.domain_suffix)
             ])
 


### PR DESCRIPTION
With latest dnsdock image we encountered resolution result errors if we
do no support IPv6.

By default we move to `tonistiigi/dnsdock:v1.10.0` and permit to override
through the config.