### PR TITLE
Removes __future__ unicode_literals

### DIFF
--- a/bag8/cli.py
+++ b/bag8/cli.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 
 import os.path
 import sys

--- a/bag8/config.py
+++ b/bag8/config.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 import click
 import os

--- a/bag8/project.py
+++ b/bag8/project.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 import os
 import yaml

--- a/bag8/service.py
+++ b/bag8/service.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 import os
 import shlex

--- a/bag8/tests/plugin.py
+++ b/bag8/tests/plugin.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 import os
 import yaml

--- a/bag8/tests/test_cli.py
+++ b/bag8/tests/test_cli.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 import os
 import tempfile

--- a/bag8/tests/test_project.py
+++ b/bag8/tests/test_project.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 from mock import patch
 

--- a/bag8/tests/test_yaml.py
+++ b/bag8/tests/test_yaml.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 import os
 

--- a/bag8/tools.py
+++ b/bag8/tools.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, print_function
 
 import click
 import logging

--- a/bag8/utils.py
+++ b/bag8/utils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 import os
 import re

--- a/bag8/yaml.py
+++ b/bag8/yaml.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division, print_function, unicode_literals  # noqa
+from __future__ import absolute_import, division, print_function
 
 import click
 import os


### PR DESCRIPTION
click does not like it and print errors: `Warning: Click detected the use of the unicode_literals __future__ import ...`

We do not need it here.